### PR TITLE
345207: Add endpoints to onboard team flux configuation

### DIFF
--- a/src/ADP.Portal.Api/ADP.Portal.Api.csproj
+++ b/src/ADP.Portal.Api/ADP.Portal.Api.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Azure.Identity" Version="1.10.4" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.5.0" />
     <PackageReference Include="Mapster" Version="7.4.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.58.1" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="4.5.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.6" />

--- a/src/ADP.Portal.Api/ADP.Portal.Api.csproj
+++ b/src/ADP.Portal.Api/ADP.Portal.Api.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>0.1.5</Version>
+    <Version>0.1.6</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <InvariantGlobalization>true</InvariantGlobalization>

--- a/src/ADP.Portal.Api/ADP.Portal.Api.http
+++ b/src/ADP.Portal.Api/ADP.Portal.Api.http
@@ -17,6 +17,7 @@ POST {{ADP.Portal.Api_HostAddress}}/api/fluxconfig/generate/ffc-demo/ffc-demo-cl
 # Create Team config
 POST {{ADP.Portal.Api_HostAddress}}/api/fluxconfig/create/ffc-find
 Content-Type: application/json
+Api-Version: 1.0
 
 {
   "ProgrammeName": "ffc",

--- a/src/ADP.Portal.Api/ADP.Portal.Api.http
+++ b/src/ADP.Portal.Api/ADP.Portal.Api.http
@@ -1,20 +1,21 @@
 ﻿@ADP.Portal.Api_HostAddress = https://localhost:7280
 
+# ADO Controller
 GET {{ADP.Portal.Api_HostAddress}}/api/adoproject/string
 
+# AD Group Controller
 ###
 PUT {{ADP.Portal.Api_HostAddress}}/api/aadgroup/sync/ffc-demo/UserGroupsMembers
 
+# Flux Config Controller
 ###
-# Generate Team templates
-POST {{ADP.Portal.Api_HostAddress}}/api/fluxconfig/generate/ffc-demo
+@serviceName = ffc-demo-claim-service
+POST {{ADP.Portal.Api_HostAddress}}/api/fluxconfig/generate/ffc-demo/{{serviceName}}
 
 ###
-# Generate Specific service templates
-POST {{ADP.Portal.Api_HostAddress}}/api/fluxconfig/generate/ffc-demo/ffc-demo-claim-service
+GET {{ADP.Portal.Api_HostAddress}}/api/fluxconfig/get/ffc-demo
 
 ###
-# Create Team config
 POST {{ADP.Portal.Api_HostAddress}}/api/fluxconfig/create/ffc-find
 Content-Type: application/json
 Api-Version: 1.0
@@ -42,9 +43,6 @@ Api-Version: 1.0
 }
 
 ###
-
-###
-# Update Team config
 PUT {{ADP.Portal.Api_HostAddress}}/api/fluxconfig/update/ffc-find
 Content-Type: application/json
 

--- a/src/ADP.Portal.Api/ADP.Portal.Api.http
+++ b/src/ADP.Portal.Api/ADP.Portal.Api.http
@@ -9,7 +9,64 @@ PUT {{ADP.Portal.Api_HostAddress}}/api/aadgroup/sync/ffc-demo/UserGroupsMembers
 # Generate Team templates
 POST {{ADP.Portal.Api_HostAddress}}/api/fluxconfig/generate/ffc-demo
 
-
 ###
 # Generate Specific service templates
 POST {{ADP.Portal.Api_HostAddress}}/api/fluxconfig/generate/ffc-demo/ffc-demo-claim-service
+
+###
+# Create Team config
+POST {{ADP.Portal.Api_HostAddress}}/api/fluxconfig/create/ffc-find
+Content-Type: application/json
+
+{
+  "ProgrammeName": "ffc",
+  "ServiceCode": "ffc-find",
+  "Services": [
+    {
+      "Name": "ffc-find-web",
+      "IsFrontend": false,
+      "Environments": [
+        "snd1",
+        "snd2",
+        "snd3"
+      ],
+      "ConfigVariables": {
+        "INGRESS_ENDPOINT": "ffc-find-web"
+      }
+    }
+  ],
+  "ConfigVariables": {
+    "TEAM_CPU_QUOTA": "2000"
+  }
+}
+
+###
+
+###
+# Update Team config
+PUT {{ADP.Portal.Api_HostAddress}}/api/fluxconfig/update/ffc-find
+Content-Type: application/json
+
+{
+  "ProgrammeName": "ffc",
+  "ServiceCode": "ffc-find",
+  "Services": [
+    {
+      "Name": "ffc-find-web",
+      "IsFrontend": true,
+      "Environments": [
+        "snd1",
+        "snd2",
+        "snd3"
+      ],
+      "ConfigVariables": {
+        "INGRESS_ENDPOINT": "ffc-find-web"
+      }
+    }
+  ],
+  "ConfigVariables": {
+    "TEAM_CPU_QUOTA": "2000"
+  }
+}
+
+###

--- a/src/ADP.Portal.Api/Controllers/AadGroupController.cs
+++ b/src/ADP.Portal.Api/Controllers/AadGroupController.cs
@@ -1,5 +1,5 @@
 ﻿using ADP.Portal.Api.Config;
-using ADP.Portal.Api.Models;
+using ADP.Portal.Api.Models.Group;
 using ADP.Portal.Core.Git.Entities;
 using ADP.Portal.Core.Git.Services;
 using Mapster;

--- a/src/ADP.Portal.Api/Controllers/AadGroupController.cs
+++ b/src/ADP.Portal.Api/Controllers/AadGroupController.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Options;
 namespace ADP.Portal.Api.Controllers
 {
     [Route("api/[controller]")]
+    [ApiVersion("1")]
     [ApiController]
     public class AadGroupController : ControllerBase
     {

--- a/src/ADP.Portal.Api/Controllers/AdoProjectController.cs
+++ b/src/ADP.Portal.Api/Controllers/AdoProjectController.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Options;
 namespace ADP.Portal.Api.Controllers
 {
     [Route("api/[controller]")]
+    [ApiVersion("1")]
     [ApiController]
     public class AdoProjectController : ControllerBase
     {

--- a/src/ADP.Portal.Api/Controllers/AdoProjectController.cs
+++ b/src/ADP.Portal.Api/Controllers/AdoProjectController.cs
@@ -1,5 +1,5 @@
 ﻿using ADP.Portal.Api.Config;
-using ADP.Portal.Api.Models;
+using ADP.Portal.Api.Models.Ado;
 using ADP.Portal.Core.Ado.Dtos;
 using ADP.Portal.Core.Ado.Entities;
 using ADP.Portal.Core.Ado.Services;

--- a/src/ADP.Portal.Api/Controllers/FluxConfigController.cs
+++ b/src/ADP.Portal.Api/Controllers/FluxConfigController.cs
@@ -10,6 +10,7 @@ using YamlDotNet.Core;
 namespace ADP.Portal.Api.Controllers
 {
     [Route("api/[controller]")]
+    [ApiVersion("1")]
     [ApiController]
     public class FluxConfigController : Controller
     {

--- a/src/ADP.Portal.Api/Controllers/FluxConfigController.cs
+++ b/src/ADP.Portal.Api/Controllers/FluxConfigController.cs
@@ -5,7 +5,6 @@ using ADP.Portal.Core.Git.Services;
 using Mapster;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
-using YamlDotNet.Core;
 
 namespace ADP.Portal.Api.Controllers
 {
@@ -28,6 +27,18 @@ namespace ADP.Portal.Api.Controllers
             this.teamGitRepoConfig = teamGitRepoConfig;
             this.azureAdConfig = azureAdConfig;
             this.fluxServicesGitRepoConfig = fluxServicesGitRepoConfig;
+        }
+
+        [HttpGet("get/{teamName}", Name = "Get")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<ActionResult> GetConfigAsync(string teamName)
+        {
+            var teamRepo = teamGitRepoConfig.Value.Adapt<GitRepo>();
+
+            var result = await gitOpsFluxTeamConfigService.GetFluxConfigAsync<FluxTeamConfig>(teamRepo, teamName: teamName);
+            
+            return Ok(result);
         }
 
         [HttpPost("create/{teamName}", Name = "Create")]

--- a/src/ADP.Portal.Api/Controllers/FluxConfigController.cs
+++ b/src/ADP.Portal.Api/Controllers/FluxConfigController.cs
@@ -1,9 +1,11 @@
 ﻿using ADP.Portal.Api.Config;
+using ADP.Portal.Api.Models.Flux;
 using ADP.Portal.Core.Git.Entities;
 using ADP.Portal.Core.Git.Services;
 using Mapster;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
+using YamlDotNet.Core;
 
 namespace ADP.Portal.Api.Controllers
 {
@@ -27,7 +29,41 @@ namespace ADP.Portal.Api.Controllers
             this.fluxServicesGitRepoConfig = fluxServicesGitRepoConfig;
         }
 
+        [HttpPost("create/{teamName}", Name = "Create")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<ActionResult> CreateConfigAsync(string teamName, [FromBody] CreateFluxConfigRequest createFluxConfigRequest)
+        {
+            var teamRepo = teamGitRepoConfig.Value.Adapt<GitRepo>();
+
+            var newTeamConfig = createFluxConfigRequest.Adapt<FluxTeamConfig>();
+
+            var result = await gitOpsFluxTeamConfigService.CreateFluxConfigAsync(teamRepo, teamName, newTeamConfig);
+            if (result.Errors.Count > 0) return BadRequest(result.Errors);
+
+            return Ok();
+        }
+
+        [HttpPut("update/{teamName}", Name = "Update")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<ActionResult> UpdateConfigAsync(string teamName, [FromBody] CreateFluxConfigRequest createFluxConfigRequest)
+        {
+            var teamRepo = teamGitRepoConfig.Value.Adapt<GitRepo>();
+
+            var newTeamConfig = createFluxConfigRequest.Adapt<FluxTeamConfig>();
+
+            var result = await gitOpsFluxTeamConfigService.UpdateFluxConfigAsync(teamRepo, teamName, newTeamConfig);
+
+            if (!result.IsConfigExists) return BadRequest($"Flux config not found for the team:{teamName}");
+            if (result.Errors.Count > 0) return BadRequest(result.Errors);
+
+            return Ok();
+        }
+
         [HttpPost("generate/{teamName}/{serviceName?}", Name = "Generate")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<ActionResult> GenerateAsync(string teamName, string? serviceName)
         {
             var teamRepo = teamGitRepoConfig.Value.Adapt<GitRepo>();
@@ -38,15 +74,8 @@ namespace ADP.Portal.Api.Controllers
             logger.LogInformation("Sync Flux Services for the Team:{TeamName}", teamName);
             var result = await gitOpsFluxTeamConfigService.GenerateFluxTeamConfigAsync(teamRepo, fluxServicesRepo, tenantName, teamName, serviceName);
 
-            if (result.Errors.Count > 0)
-            {
-                if (!result.IsConfigExists)
-                {
-                    return BadRequest($"Flux generator config not for the team:{teamName}");
-                }
-
-                return BadRequest(result.Errors);
-            }
+            if (!result.IsConfigExists) return BadRequest($"Flux generator config not found for the team:{teamName}");
+            if (result.Errors.Count > 0) return BadRequest(result.Errors);
 
             return Ok();
         }

--- a/src/ADP.Portal.Api/Mapster/MapsterEntitiesConfig.cs
+++ b/src/ADP.Portal.Api/Mapster/MapsterEntitiesConfig.cs
@@ -1,9 +1,10 @@
-﻿using ADP.Portal.Core.Ado.Entities;
+﻿using System.Reflection;
+using ADP.Portal.Api.Models.Flux;
+using ADP.Portal.Core.Ado.Entities;
 using ADP.Portal.Core.Azure.Entities;
 using Mapster;
 using Microsoft.Graph.Models;
 using Microsoft.TeamFoundation.DistributedTask.WebApi;
-using System.Reflection;
 
 namespace ADP.Portal.Api.Mapster
 {
@@ -31,6 +32,9 @@ namespace ADP.Portal.Api.Mapster
                     }
                   });
 
+            TypeAdapterConfig<FluxService, Core.Git.Entities.FluxService>.NewConfig()
+                .Map(dest => dest.Environments, opt => opt.Environments.Select(x => new Core.Git.Entities.FluxEnvironment { Name = x }))
+                .Map(dest => dest.Type, opt => opt.IsFrontend ? Core.Git.Entities.FluxServiceType.Frontend : Core.Git.Entities.FluxServiceType.Backend);
         }
     }
 }

--- a/src/ADP.Portal.Api/Models/Ado/AdoEnvironment.cs
+++ b/src/ADP.Portal.Api/Models/Ado/AdoEnvironment.cs
@@ -1,4 +1,4 @@
-﻿namespace ADP.Portal.Api.Models
+﻿namespace ADP.Portal.Api.Models.Ado
 {
     public class AdoEnvironment
     {

--- a/src/ADP.Portal.Api/Models/Ado/AdoVariable.cs
+++ b/src/ADP.Portal.Api/Models/Ado/AdoVariable.cs
@@ -1,4 +1,4 @@
-﻿namespace ADP.Portal.Api.Models
+﻿namespace ADP.Portal.Api.Models.Ado
 {
     public class AdoVariable
     {

--- a/src/ADP.Portal.Api/Models/Ado/AdoVariableGroup.cs
+++ b/src/ADP.Portal.Api/Models/Ado/AdoVariableGroup.cs
@@ -1,4 +1,4 @@
-﻿namespace ADP.Portal.Api.Models
+﻿namespace ADP.Portal.Api.Models.Ado
 {
     public class AdoVariableGroup
     {

--- a/src/ADP.Portal.Api/Models/Ado/OnBoardAdoProjectRequest.cs
+++ b/src/ADP.Portal.Api/Models/Ado/OnBoardAdoProjectRequest.cs
@@ -1,4 +1,4 @@
-﻿namespace ADP.Portal.Api.Models
+﻿namespace ADP.Portal.Api.Models.Ado
 {
     public class OnBoardAdoProjectRequest
     {

--- a/src/ADP.Portal.Api/Models/Flux/CreateFluxConfigRequest.cs
+++ b/src/ADP.Portal.Api/Models/Flux/CreateFluxConfigRequest.cs
@@ -1,0 +1,10 @@
+﻿namespace ADP.Portal.Api.Models.Flux
+{
+    public class CreateFluxConfigRequest
+    {
+        public required string ProgrammeName { get; set; }
+        public required string ServiceCode { get; set; }
+        public required List<FluxService> Services { get; set; }
+        public Dictionary<string, string> ConfigVariables { get; set; } = [];
+    }
+}

--- a/src/ADP.Portal.Api/Models/Flux/FluxService.cs
+++ b/src/ADP.Portal.Api/Models/Flux/FluxService.cs
@@ -1,0 +1,10 @@
+﻿namespace ADP.Portal.Api.Models.Flux
+{
+    public class FluxService
+    {
+        public required string Name { get; set; }
+        public required bool IsFrontend { get; set; }
+        public List<string> Environments { get; set; } = [];
+        public Dictionary<string, string> ConfigVariables { get; set; } = [];
+    }
+}

--- a/src/ADP.Portal.Api/Models/Group/SyncConfigType.cs
+++ b/src/ADP.Portal.Api/Models/Group/SyncConfigType.cs
@@ -1,4 +1,4 @@
-﻿namespace ADP.Portal.Api.Models
+﻿namespace ADP.Portal.Api.Models.Group
 {
     public enum SyncConfigType
     {

--- a/src/ADP.Portal.Api/Models/Group/SyncGroupType.cs
+++ b/src/ADP.Portal.Api/Models/Group/SyncGroupType.cs
@@ -1,4 +1,4 @@
-﻿namespace ADP.Portal.Api.Models
+﻿namespace ADP.Portal.Api.Models.Group
 {
     public enum SyncGroupType
     {

--- a/src/ADP.Portal.Api/Program.cs
+++ b/src/ADP.Portal.Api/Program.cs
@@ -12,6 +12,7 @@ using ADP.Portal.Core.Git.Infrastructure;
 using ADP.Portal.Core.Git.Jwt;
 using ADP.Portal.Core.Git.Services;
 using Azure.Identity;
+using Microsoft.AspNetCore.Mvc.Versioning;
 using Microsoft.Extensions.Options;
 using Microsoft.Graph;
 using Microsoft.OpenApi.Models;
@@ -110,6 +111,13 @@ namespace ADP.Portal.Api
             {
                 c.SwaggerDoc("v1", new OpenApiInfo { Title = "Adp.Portal.Api", Version = "v1" });
                 c.OperationFilter<OptionalPathParameterOperationFilter>();
+            });
+            builder.Services.AddApiVersioning(config =>
+            {
+                config.DefaultApiVersion = new Microsoft.AspNetCore.Mvc.ApiVersion(1, 0);
+                config.AssumeDefaultVersionWhenUnspecified = true;
+                config.ReportApiVersions = true;
+                config.ApiVersionReader = new HeaderApiVersionReader("api-version");
             });
         }
 

--- a/src/ADP.Portal.Api/appsettings.Development.json
+++ b/src/ADP.Portal.Api/appsettings.Development.json
@@ -15,7 +15,7 @@
   },
   "TeamGitRepo": {
     "Name": "adp-team-onboard",
-    "BranchName": "features/flux-services",
+    "BranchName": "main",
     "Organisation": "defra-adp-sandpit"
   },
   "FluxServicesGitRepo": {

--- a/src/ADP.Portal.Core/Git/Entities/CreateFluxConfigResult.cs
+++ b/src/ADP.Portal.Core/Git/Entities/CreateFluxConfigResult.cs
@@ -1,6 +1,6 @@
 ﻿namespace ADP.Portal.Core.Git.Entities
 {
-    public class GenerateFluxConfigResult
+    public class CreateFluxConfigResult
     {
         public bool IsConfigExists { get; set; } = true;
 

--- a/src/ADP.Portal.Core/Git/Entities/Group.cs
+++ b/src/ADP.Portal.Core/Git/Entities/Group.cs
@@ -1,6 +1,4 @@
-﻿
-
-namespace ADP.Portal.Core.Git.Entities
+﻿namespace ADP.Portal.Core.Git.Entities
 {
     public class Group()
     {

--- a/src/ADP.Portal.Core/Git/Infrastructure/IGitOpsConfigRepository.cs
+++ b/src/ADP.Portal.Core/Git/Infrastructure/IGitOpsConfigRepository.cs
@@ -7,6 +7,10 @@ namespace ADP.Portal.Core.Git.Infrastructure
     {
         Task<T?> GetConfigAsync<T>(string fileName, GitRepo gitRepo);
 
+        Task CreateConfigAsync(GitRepo gitRepo, string fileName, string content);
+
+        Task UpdateConfigAsync(GitRepo gitRepo, string fileName, string content);
+
         Task<IEnumerable<KeyValuePair<string, Dictionary<object, object>>>> GetAllFilesAsync(GitRepo gitRepo, string path);
 
         Task<Reference?> GetBranchAsync(GitRepo gitRepo, string branchName);

--- a/src/ADP.Portal.Core/Git/Services/IGitOpsFluxTeamConfigService.cs
+++ b/src/ADP.Portal.Core/Git/Services/IGitOpsFluxTeamConfigService.cs
@@ -4,6 +4,8 @@ namespace ADP.Portal.Core.Git.Services
 {
     public interface IGitOpsFluxTeamConfigService
     {
+        Task<T?> GetFluxConfigAsync<T>(GitRepo gitRepo, string? tenantName = null, string? teamName = null);
+
         Task<CreateFluxConfigResult> CreateFluxConfigAsync(GitRepo gitRepo, string teamName, FluxTeamConfig fluxTeamConfig);
 
         Task<CreateFluxConfigResult> UpdateFluxConfigAsync(GitRepo gitRepo, string teamName, FluxTeamConfig fluxTeamConfig);

--- a/src/ADP.Portal.Core/Git/Services/IGitOpsFluxTeamConfigService.cs
+++ b/src/ADP.Portal.Core/Git/Services/IGitOpsFluxTeamConfigService.cs
@@ -4,6 +4,10 @@ namespace ADP.Portal.Core.Git.Services
 {
     public interface IGitOpsFluxTeamConfigService
     {
+        Task<CreateFluxConfigResult> CreateFluxConfigAsync(GitRepo gitRepo, string teamName, FluxTeamConfig fluxTeamConfig);
+
+        Task<CreateFluxConfigResult> UpdateFluxConfigAsync(GitRepo gitRepo, string teamName, FluxTeamConfig fluxTeamConfig);
+
         Task<GenerateFluxConfigResult> GenerateFluxTeamConfigAsync(GitRepo gitRepo, GitRepo gitRepoFluxServices, string tenantName, string teamName, string? serviceName = null);
     }
 }

--- a/test/ADP.Portal.Api.Tests/Controllers/AdoProjectControllerTests.cs
+++ b/test/ADP.Portal.Api.Tests/Controllers/AdoProjectControllerTests.cs
@@ -1,6 +1,6 @@
 ﻿using ADP.Portal.Api.Config;
 using ADP.Portal.Api.Controllers;
-using ADP.Portal.Api.Models;
+using ADP.Portal.Api.Models.Ado;
 using ADP.Portal.Core.Ado.Dtos;
 using ADP.Portal.Core.Ado.Entities;
 using ADP.Portal.Core.Ado.Services;

--- a/test/ADP.Portal.Api.Tests/Controllers/FluxConfigControllerTests.cs
+++ b/test/ADP.Portal.Api.Tests/Controllers/FluxConfigControllerTests.cs
@@ -223,5 +223,31 @@ namespace ADP.Portal.Api.Tests.Controllers
                 Assert.That(okResults, Is.Not.Null);
             }
         }
+
+        [Test]
+        public async Task GetConfigAsync_Returns_Ok()
+        {
+            // Arrange
+            var fluxTeam = fixture.Build<FluxTeamConfig>().Create();
+            teamGitRepoConfigMock.Value.Returns(fixture.Build<TeamGitRepoConfig>().Create());
+            fluxServicesGitRepoConfigMock.Value.Returns(fixture.Build<FluxServicesGitRepoConfig>().Create());
+            gitOpsFluxTeamConfigServiceMock.GetFluxConfigAsync<FluxTeamConfig>(Arg.Any<GitRepo>(), Arg.Any<string>(), Arg.Any<string>())
+                .Returns(fluxTeam);
+
+            // Act
+            var result = await controller.GetConfigAsync("teamName");
+
+            // Assert
+            Assert.That(result, Is.InstanceOf<OkObjectResult>());
+            if (result != null)
+            {
+                var okResults = (OkObjectResult)result;
+                var fluxTeamConfig = okResults.Value as FluxTeamConfig;
+                
+                Assert.That(okResults, Is.Not.Null);
+                Assert.That(fluxTeamConfig, Is.Not.Null);
+                Assert.That(fluxTeamConfig?.Services.Count, Is.EqualTo(fluxTeam.Services.Count));
+            }
+        }
     }
 }

--- a/test/ADP.Portal.Api.Tests/Controllers/FluxConfigControllerTests.cs
+++ b/test/ADP.Portal.Api.Tests/Controllers/FluxConfigControllerTests.cs
@@ -1,11 +1,14 @@
 ﻿using System.Reflection;
 using ADP.Portal.Api.Config;
 using ADP.Portal.Api.Controllers;
+using ADP.Portal.Api.Mapster;
+using ADP.Portal.Api.Models.Flux;
 using ADP.Portal.Core.Git.Entities;
 using ADP.Portal.Core.Git.Services;
 using AutoFixture;
 using Mapster;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NSubstitute;
@@ -28,6 +31,7 @@ namespace ADP.Portal.Api.Tests.Controllers
         public void SetUp()
         {
             TypeAdapterConfig.GlobalSettings.Scan(Assembly.GetExecutingAssembly());
+            MapsterEntitiesConfig.EntitiesConfigure(Substitute.For<IServiceCollection>());
         }
 
         public FluxConfigControllerTests()
@@ -42,7 +46,7 @@ namespace ADP.Portal.Api.Tests.Controllers
         }
 
         [Test]
-        public async Task GenerateAsync_Returns_OkRequest()
+        public async Task GenerateAsync_Returns_Ok()
         {
             // Arrange
             teamGitRepoConfigMock.Value.Returns(fixture.Build<TeamGitRepoConfig>().Create());
@@ -67,7 +71,7 @@ namespace ADP.Portal.Api.Tests.Controllers
             fluxServicesGitRepoConfigMock.Value.Returns(fixture.Build<FluxServicesGitRepoConfig>().Create());
             azureAdConfigMock.Value.Returns(fixture.Build<AzureAdConfig>().Create());
             gitOpsFluxTeamConfigServiceMock.GenerateFluxTeamConfigAsync(Arg.Any<GitRepo>(), Arg.Any<GitRepo>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())
-                .Returns(new GenerateFluxConfigResult() {  IsConfigExists =false, Errors= ["Flux team config not found"] } );
+                .Returns(new GenerateFluxConfigResult() { IsConfigExists = false, Errors = ["Flux team config not found"] });
 
             // Act
             var result = await controller.GenerateAsync("teamName", "service1");
@@ -79,7 +83,7 @@ namespace ADP.Portal.Api.Tests.Controllers
                 var badResults = (BadRequestObjectResult)result;
                 Assert.That(badResults, Is.Not.Null);
                 Assert.That(badResults.StatusCode, Is.EqualTo(400));
-                Assert.That(badResults.Value, Is.EqualTo($"Flux generator config not for the team:teamName"));
+                Assert.That(badResults.Value, Is.EqualTo($"Flux generator config not found for the team:teamName"));
             }
         }
 
@@ -103,6 +107,120 @@ namespace ADP.Portal.Api.Tests.Controllers
                 var badResults = (BadRequestObjectResult)result;
                 Assert.That(badResults, Is.Not.Null);
                 Assert.That(badResults.StatusCode, Is.EqualTo(400));
+            }
+        }
+
+        [Test]
+        public async Task CreateConfigAsync_Returns_BadRequest()
+        {
+            // Arrange
+            var request = fixture.Build<CreateFluxConfigRequest>().Create();
+            teamGitRepoConfigMock.Value.Returns(fixture.Build<TeamGitRepoConfig>().Create());
+            fluxServicesGitRepoConfigMock.Value.Returns(fixture.Build<FluxServicesGitRepoConfig>().Create());
+            gitOpsFluxTeamConfigServiceMock.CreateFluxConfigAsync(Arg.Any<GitRepo>(), Arg.Any<string>(), Arg.Any<FluxTeamConfig>())
+                .Returns(new CreateFluxConfigResult() { Errors = ["Flux team config not found"] });
+
+            // Act
+            var result = await controller.CreateConfigAsync("teamName", request);
+
+            // Assert
+            Assert.That(result, Is.InstanceOf<BadRequestObjectResult>());
+            if (result != null)
+            {
+                var badResults = (BadRequestObjectResult)result;
+                Assert.That(badResults, Is.Not.Null);
+                Assert.That(badResults.StatusCode, Is.EqualTo(400));
+            }
+        }
+
+        [Test]
+        public async Task CreateConfigAsync_Returns_Ok()
+        {
+            // Arrange
+            var request = fixture.Build<CreateFluxConfigRequest>().Create();
+            teamGitRepoConfigMock.Value.Returns(fixture.Build<TeamGitRepoConfig>().Create());
+            fluxServicesGitRepoConfigMock.Value.Returns(fixture.Build<FluxServicesGitRepoConfig>().Create());
+            gitOpsFluxTeamConfigServiceMock.CreateFluxConfigAsync(Arg.Any<GitRepo>(), Arg.Any<string>(), Arg.Any<FluxTeamConfig>())
+                .Returns(new CreateFluxConfigResult());
+
+            // Act
+            var result = await controller.CreateConfigAsync("teamName", request);
+
+            // Assert
+            Assert.That(result, Is.InstanceOf<OkResult>());
+            if (result != null)
+            {
+                var okResults = (OkResult)result;
+                Assert.That(okResults, Is.Not.Null);
+            }
+        }
+
+        [Test]
+        public async Task UpdateConfigAsync_Returns_BadRequest_When_FileNotFound()
+        {
+            // Arrange
+            var request = fixture.Build<CreateFluxConfigRequest>().Create();
+            teamGitRepoConfigMock.Value.Returns(fixture.Build<TeamGitRepoConfig>().Create());
+            fluxServicesGitRepoConfigMock.Value.Returns(fixture.Build<FluxServicesGitRepoConfig>().Create());
+            gitOpsFluxTeamConfigServiceMock.UpdateFluxConfigAsync(Arg.Any<GitRepo>(), Arg.Any<string>(), Arg.Any<FluxTeamConfig>())
+                .Returns(new CreateFluxConfigResult() { IsConfigExists = false });
+
+            // Act
+            var result = await controller.UpdateConfigAsync("teamName", request);
+
+            // Assert
+            Assert.That(result, Is.InstanceOf<BadRequestObjectResult>());
+            if (result != null)
+            {
+                var badResults = (BadRequestObjectResult)result;
+                Assert.That(badResults, Is.Not.Null);
+                Assert.That(badResults.StatusCode, Is.EqualTo(400));
+                Assert.That(badResults.Value, Is.EqualTo($"Flux config not found for the team:teamName"));
+            }
+        }
+
+        [Test]
+        public async Task UpdateConfigAsync_Returns_BadRequest_When_Errors()
+        {
+            // Arrange
+            var request = fixture.Build<CreateFluxConfigRequest>().Create();
+            teamGitRepoConfigMock.Value.Returns(fixture.Build<TeamGitRepoConfig>().Create());
+            fluxServicesGitRepoConfigMock.Value.Returns(fixture.Build<FluxServicesGitRepoConfig>().Create());
+            gitOpsFluxTeamConfigServiceMock.UpdateFluxConfigAsync(Arg.Any<GitRepo>(), Arg.Any<string>(), Arg.Any<FluxTeamConfig>())
+                .Returns(new CreateFluxConfigResult() { Errors = ["Flux team config not found"] });
+
+            // Act
+            var result = await controller.UpdateConfigAsync("teamName", request);
+
+            // Assert
+            Assert.That(result, Is.InstanceOf<BadRequestObjectResult>());
+            if (result != null)
+            {
+                var badResults = (BadRequestObjectResult)result;
+                Assert.That(badResults, Is.Not.Null);
+                Assert.That(badResults.StatusCode, Is.EqualTo(400));
+            }
+        }
+
+        [Test]
+        public async Task UpdateConfigAsync_Returns_Ok()
+        {
+            // Arrange
+            var request = fixture.Build<CreateFluxConfigRequest>().Create();
+            teamGitRepoConfigMock.Value.Returns(fixture.Build<TeamGitRepoConfig>().Create());
+            fluxServicesGitRepoConfigMock.Value.Returns(fixture.Build<FluxServicesGitRepoConfig>().Create());
+            gitOpsFluxTeamConfigServiceMock.UpdateFluxConfigAsync(Arg.Any<GitRepo>(), Arg.Any<string>(), Arg.Any<FluxTeamConfig>())
+                .Returns(new CreateFluxConfigResult());
+
+            // Act
+            var result = await controller.UpdateConfigAsync("teamName", request);
+
+            // Assert
+            Assert.That(result, Is.InstanceOf<OkResult>());
+            if (result != null)
+            {
+                var okResults = (OkResult)result;
+                Assert.That(okResults, Is.Not.Null);
             }
         }
     }

--- a/test/ADP.Portal.Api.Tests/ProgramTests.cs
+++ b/test/ADP.Portal.Api.Tests/ProgramTests.cs
@@ -98,5 +98,21 @@ namespace ADP.Portal.Api.Tests
             // Assert
             Assert.That(result, Is.Not.Null);
         }
+
+        [Test]
+        public void TestApiVersioningConfiguration()
+        {
+            // Arrange
+            var builder = WebApplication.CreateBuilder();
+            Program.ConfigureApp(builder);
+
+            // Act
+            var app = builder.Build();
+            app.MapControllers();
+            var result = app.Services.GetService<IAzureCredential>();
+
+            // Assert
+            Assert.That(result, Is.Not.Null);
+        }
     }
 }


### PR DESCRIPTION
# **What this PR does / why we need it**:
Add endpoint to read, create & update flux team configuration.
Add versioning scheme for all the APIs and defaulted the version to 1.
Relates to ADO Work Item [AB#345207](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/345207)

# **Special notes for your reviewer**
N/A

# Testing
N/A

# **How does this PR make you feel**:
![gif]([https://giphy.com/)