### PR TITLE
346049: Added flux manifest generation support for Helm only service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -398,3 +398,4 @@ FodyWeavers.xsd
 *.sln.iml
 
 .mono/
+**/lcov.info

--- a/src/ADP.Portal.Api/ADP.Portal.Api.csproj
+++ b/src/ADP.Portal.Api/ADP.Portal.Api.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>0.1.20</Version>
+    <Version>0.1.21</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <InvariantGlobalization>true</InvariantGlobalization>

--- a/src/ADP.Portal.Api/ADP.Portal.Api.csproj
+++ b/src/ADP.Portal.Api/ADP.Portal.Api.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>0.1.19</Version>
+    <Version>0.1.20</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <InvariantGlobalization>true</InvariantGlobalization>

--- a/src/ADP.Portal.Api/ADP.Portal.Api.http
+++ b/src/ADP.Portal.Api/ADP.Portal.Api.http
@@ -22,9 +22,104 @@ PUT {{ADP.Portal.Api_HostAddress}}/api/aadgroup/sync/ffc-demo/UserGroupsMembers
 
 # Flux Config Controller
 ###
-@serviceName = ffc-demo-claim-service
-POST {{ADP.Portal.Api_HostAddress}}/api/fluxteamconfig/ffc-demo/generate?serviceName={{serviceName}}
+# Create a team
+POST {{ADP.Portal.Api_HostAddress}}/api/fluxteamconfig/test-demo
+Content-Type: application/json
 
+{
+  "ProgrammeName": "ffc",
+  "ServiceCode": "test-demo",
+  "TeamName": "test-demo",
+  "Services": [
+  ],
+  "ConfigVariables": {
+    "TEAM_CPU_QUOTA": "2000",
+    "TEAM_MEMORY_QUOTA": "3000Mi",
+    "TEAM_PODS_QUOTA": "20"
+  }
+}
+
+###
+
+# Update a team
+PUT {{ADP.Portal.Api_HostAddress}}/api/fluxteamconfig/test-demo
+Content-Type: application/json
+
+{
+  "ProgrammeName": "ffc",
+  "ServiceCode": "test-demo",
+  "TeamName": "test-demo",
+  "Services": [
+  ],
+  "ConfigVariables": {
+    "TEAM_CPU_QUOTA": "2000",
+    "TEAM_MEMORY_QUOTA": "3000Mi",
+    "TEAM_PODS_QUOTA": "20"
+  }
+}
+
+###
+# Helm only ingress app
+POST {{ADP.Portal.Api_HostAddress}}/api/fluxteamconfig/test-demo/services
+Content-Type: application/json
+
+{
+    "Name": "test-ingress-3",
+    "IsFrontend": true,
+    "IsHelmOnly": true,
+    "Environments": [
+        "snd1",
+        "snd2",
+        "snd3"
+    ],
+    "ConfigVariables": {}
+}
+
+###
+# Generate flux service manifest for helm only app
+POST {{ADP.Portal.Api_HostAddress}}/api/fluxteamconfig/test-demo/generate?serviceName=test-ingress-3
+
+###
+# Frontend app
+POST {{ADP.Portal.Api_HostAddress}}/api/fluxteamconfig/test-demo/services
+Content-Type: application/json
+
+{
+    "Name": "ffc-frontend-2",
+    "IsFrontend": true,
+    "Environments": [
+        "snd1",
+        "snd2",
+        "snd3"
+    ],
+    "ConfigVariables": {}
+}
+
+###
+
+POST {{ADP.Portal.Api_HostAddress}}/api/fluxteamconfig/test-demo/generate?serviceName=ffc-frontend-2
+
+###
+# Backend app
+POST {{ADP.Portal.Api_HostAddress}}/api/fluxteamconfig/test-demo/services
+Content-Type: application/json
+
+{
+    "Name": "ffc-backend-2",
+    "IsFrontend": false,
+    "Environments": [
+        "snd1",
+        "snd2",
+        "snd3"
+    ],
+    "ConfigVariables": {
+        "POSTGRES_DB":"test-demo-backend"
+    }
+}
+
+###
+
+POST {{ADP.Portal.Api_HostAddress}}/api/fluxteamconfig/test-demo/generate?serviceName=ffc-backend-2
 ###
 GET {{ADP.Portal.Api_HostAddress}}/api/fluxteamconfig/get/ffc-demo
 

--- a/src/ADP.Portal.Api/Mapster/FluxTeamConfigMappings.cs
+++ b/src/ADP.Portal.Api/Mapster/FluxTeamConfigMappings.cs
@@ -1,5 +1,4 @@
 ﻿using ADP.Portal.Api.Models.Flux;
-
 using Mapster;
 
 namespace ADP.Portal.Api.Mapster
@@ -14,8 +13,20 @@ namespace ADP.Portal.Api.Mapster
 
             TypeAdapterConfig<ServiceFluxConfigRequest, Core.Git.Entities.FluxService>.NewConfig()
                 .Map(dest => dest.Environments, opt => (opt.Environments ?? new()).Select(x => new Core.Git.Entities.FluxEnvironment { Name = x }))
-                .Map(dest => dest.Type, opt => opt.IsFrontend ? opt.IsHelmOnly ? Core.Git.Entities.FluxServiceType.HelmOnly : Core.Git.Entities.FluxServiceType.Frontend : Core.Git.Entities.FluxServiceType.Backend)
+                .Map(dest => dest.Type, opt => DetermineFluxServiceType(opt.IsFrontend, opt.IsHelmOnly))
                 .Map(dest => dest.ConfigVariables, opt => opt.ConfigVariables ?? new());
+        }
+
+        private static Core.Git.Entities.FluxServiceType DetermineFluxServiceType(bool isFrontend, bool isHelmOnly)
+        {
+            if (isFrontend)
+            {
+                return isHelmOnly ? Core.Git.Entities.FluxServiceType.HelmOnly : Core.Git.Entities.FluxServiceType.Frontend;
+            }
+            else
+            {
+                return Core.Git.Entities.FluxServiceType.Backend;
+            }
         }
     }
 }

--- a/src/ADP.Portal.Api/Mapster/FluxTeamConfigMappings.cs
+++ b/src/ADP.Portal.Api/Mapster/FluxTeamConfigMappings.cs
@@ -14,7 +14,7 @@ namespace ADP.Portal.Api.Mapster
 
             TypeAdapterConfig<ServiceFluxConfigRequest, Core.Git.Entities.FluxService>.NewConfig()
                 .Map(dest => dest.Environments, opt => (opt.Environments ?? new()).Select(x => new Core.Git.Entities.FluxEnvironment { Name = x }))
-                .Map(dest => dest.Type, opt => opt.IsFrontend ? Core.Git.Entities.FluxServiceType.Frontend : Core.Git.Entities.FluxServiceType.Backend)
+                .Map(dest => dest.Type, opt => opt.IsFrontend ? opt.IsHelmOnly ? Core.Git.Entities.FluxServiceType.HelmOnly : Core.Git.Entities.FluxServiceType.Frontend : Core.Git.Entities.FluxServiceType.Backend)
                 .Map(dest => dest.ConfigVariables, opt => opt.ConfigVariables ?? new());
         }
     }

--- a/src/ADP.Portal.Api/Models/Flux/ServiceFluxConfigRequest.cs
+++ b/src/ADP.Portal.Api/Models/Flux/ServiceFluxConfigRequest.cs
@@ -4,6 +4,7 @@
     {
         public required string Name { get; set; }
         public required bool IsFrontend { get; set; }
+        public bool IsHelmOnly { get; set; } = false;
         public List<string>? Environments { get; set; }
         public Dictionary<string, string>? ConfigVariables { get; set; }
     }

--- a/src/ADP.Portal.Core/Git/Entities/FluxConstants.cs
+++ b/src/ADP.Portal.Core/Git/Entities/FluxConstants.cs
@@ -19,13 +19,17 @@
         public const string INFRA_KEY = "infra";
         public const string POSTGRESRESOURCEGROUPNAME_KEY = "postgresResourceGroupName";
         public const string POSTGRESSERVERNAME_KEY = "postgresServerName";
+        public const string DEPENDS_ON_KEY = "dependsOn";
 
         public const string PROGRAMME_FOLDER = "flux/templates/programme";
         public const string SERVICE_FOLDER = "flux/templates/programme/team/service";
         public const string TEAM_ENV_FOLDER = "flux/templates/programme/team/environment";
         public const string SERVICE_PRE_DEPLOY_FOLDER = "flux/templates/programme/team/service/pre-deploy";
+        public const string SERVICE_INFRA_FOLDER = "flux/templates/programme/team/service/infra";
 
         public const string PRE_DEPLOY_KUSTOMIZE_FILE = "flux/templates/programme/team/service/pre-deploy-kustomize.yaml";
+        public const string DEPLOY_KUSTOMIZE_FILE = "flux/templates/programme/team/service/deploy-kustomize.yaml";
+        public const string INFRA_KUSTOMIZE_FILE = "flux/templates/programme/team/service/infra-kustomize.yaml";
         public const string TEAM_ENV_KUSTOMIZATION_FILE = "flux/templates/programme/team/environment/kustomization.yaml";
         public const string TEAM_SERVICE_KUSTOMIZATION_FILE = "flux/templates/programme/team/service/kustomization.yaml";
         public const string TEAM_SERVICE_DEPLOY_ENV_PATCH_FILE = "{0}/{1}/{2}/deploy/{3}/patch.yaml";

--- a/src/ADP.Portal.Core/Git/Entities/FluxService.cs
+++ b/src/ADP.Portal.Core/Git/Entities/FluxService.cs
@@ -15,7 +15,8 @@ namespace ADP.Portal.Core.Git.Entities
     public enum FluxServiceType
     {
         Frontend,
-        Backend
+        Backend,
+        HelmOnly
     }
 
     public static class FluxServiceExtensions

--- a/src/ADP.Portal.Core/Git/Services/GitOpsFluxTeamConfigService.cs
+++ b/src/ADP.Portal.Core/Git/Services/GitOpsFluxTeamConfigService.cs
@@ -3,8 +3,11 @@ using ADP.Portal.Core.Git.Extensions;
 using ADP.Portal.Core.Git.Infrastructure;
 using ADP.Portal.Core.Helpers;
 using Microsoft.Extensions.Logging;
+using Microsoft.TeamFoundation.Pipelines.WebApi;
+using Microsoft.TeamFoundation.TestManagement.WebApi;
 using Microsoft.VisualStudio.Services.Common;
 using Octokit;
+using System.Text.RegularExpressions;
 using YamlDotNet.Serialization;
 
 namespace ADP.Portal.Core.Git.Services
@@ -99,7 +102,6 @@ namespace ADP.Portal.Core.Git.Services
             logger.LogInformation("Generating flux config for the team:'{TeamName}', service:'{ServiceName}' and environment:'{Environment}'.", teamName, serviceName, environment);
             var generatedFiles = ProcessTemplates(templates, tenantConfig, teamConfig, serviceName, environment);
 
-            var branchName = $"refs/heads/features/{teamName}{(string.IsNullOrEmpty(serviceName) ? "" : $"-{serviceName}")}";
             if (generatedFiles.Count > 0) await PushFilesToFluxRepository(gitRepoFluxServices, teamName, serviceName, generatedFiles);
 
             return result;
@@ -238,10 +240,7 @@ namespace ADP.Portal.Core.Git.Services
                     if (!template.Key.Contains(FluxConstants.ENV_KEY))
                     {
                         var serviceTemplate = template.Value.DeepCopy();
-                        if (template.Key.Equals(FluxConstants.TEAM_SERVICE_KUSTOMIZATION_FILE) && service.HasDatastore())
-                        {
-                            ((List<object>)serviceTemplate[FluxConstants.RESOURCES_KEY]).Add("pre-deploy-kustomize.yaml");
-                        }
+                        serviceTemplate = UpdateServiceKustomizationFiles(serviceTemplate, template.Key, service);
                         var key = template.Key.Replace(FluxConstants.PROGRAMME_FOLDER, teamConfig.ProgrammeName).Replace(FluxConstants.TEAM_KEY, teamConfig.TeamName).Replace(FluxConstants.SERVICE_KEY, service.Name);
                         serviceFiles.Add($"services/{key}", serviceTemplate);
                     }
@@ -252,7 +251,10 @@ namespace ADP.Portal.Core.Git.Services
                 }
                 UpdateServicePatchFiles(serviceFiles, service, teamConfig);
 
-                service.ConfigVariables.Add(new FluxConfig { Key = FluxConstants.TEMPLATE_VAR_DEPENDS_ON, Value = service.HasDatastore() ? FluxConstants.PREDEPLOY_KEY : FluxConstants.INFRA_KEY });
+                if (service.Type != FluxServiceType.HelmOnly)
+                {
+                    service.ConfigVariables.Add(new FluxConfig { Key = FluxConstants.TEMPLATE_VAR_DEPENDS_ON, Value = service.HasDatastore() ? FluxConstants.PREDEPLOY_KEY : FluxConstants.INFRA_KEY });
+                }
                 service.ConfigVariables.Add(new FluxConfig { Key = FluxConstants.TEMPLATE_VAR_SERVICE_NAME, Value = service.Name });
                 service.ConfigVariables.ForEach(serviceFiles.ReplaceToken);
                 finalFiles.AddRange(serviceFiles);
@@ -269,6 +271,14 @@ namespace ADP.Portal.Core.Git.Services
                 if (!service.HasDatastore())
                 {
                     matched = !filter.Key.StartsWith(FluxConstants.SERVICE_PRE_DEPLOY_FOLDER) && !filter.Key.StartsWith(FluxConstants.PRE_DEPLOY_KUSTOMIZE_FILE);
+                }
+                return matched;
+            }).Where(filter =>
+            {
+                var matched = true;
+                if (service.Type == FluxServiceType.HelmOnly)
+                {
+                    matched = !filter.Key.StartsWith(FluxConstants.SERVICE_INFRA_FOLDER) && !filter.Key.StartsWith(FluxConstants.INFRA_KUSTOMIZE_FILE);
                 }
                 return matched;
             });
@@ -328,6 +338,23 @@ namespace ADP.Portal.Core.Git.Services
                 }
             }
             return finalFiles;
+        }
+
+        private static Dictionary<object, object> UpdateServiceKustomizationFiles(Dictionary<object, object> serviceTemplate, string templateKey, FluxService service)
+        {
+            if (templateKey.Equals(FluxConstants.TEAM_SERVICE_KUSTOMIZATION_FILE) && service.HasDatastore())
+            {
+                ((List<object>)serviceTemplate[FluxConstants.RESOURCES_KEY]).Add("pre-deploy-kustomize.yaml");
+            }
+            if (templateKey.Equals(FluxConstants.TEAM_SERVICE_KUSTOMIZATION_FILE) && service.Type == FluxServiceType.HelmOnly)
+            {
+                ((List<object>)serviceTemplate[FluxConstants.RESOURCES_KEY]).Remove("infra-kustomize.yaml");
+            }
+            if (templateKey.Equals(FluxConstants.DEPLOY_KUSTOMIZE_FILE) && service.Type == FluxServiceType.HelmOnly)
+            {
+                ((Dictionary<object, object>)serviceTemplate[FluxConstants.SPEC_KEY]).Remove(FluxConstants.DEPENDS_ON_KEY);
+            }
+            return serviceTemplate;
         }
 
         private static void UpdateServicePatchFiles(Dictionary<string, Dictionary<object, object>> serviceFiles, FluxService service, FluxTeamConfig teamConfig)

--- a/test/ADP.Portal.Api.Tests/Controllers/FluxTeamConfigControllerTests.cs
+++ b/test/ADP.Portal.Api.Tests/Controllers/FluxTeamConfigControllerTests.cs
@@ -292,10 +292,15 @@ namespace ADP.Portal.Api.Tests.Controllers
         }
 
         [Test]
-        public async Task CreateServiceAsync_Returns_Created()
+        [TestCase(true, false)]
+        [TestCase(false, false)]
+        [TestCase(true, true)]
+        public async Task CreateServiceAsync_Returns_Created(bool isFrontend, bool isHelmOnly)
         {
             // Arrange
             var request = fixture.Build<ServiceFluxConfigRequest>().Create();
+            request.IsFrontend = isFrontend;
+            request.IsHelmOnly = isHelmOnly;
             teamGitRepoConfigMock.Value.Returns(fixture.Build<TeamGitRepoConfig>().Create());
             fluxServicesGitRepoConfigMock.Value.Returns(fixture.Build<FluxServicesGitRepoConfig>().Create());
             gitOpsFluxTeamConfigServiceMock.AddServiceAsync(Arg.Any<GitRepo>(), Arg.Any<string>(), Arg.Any<Core.Git.Entities.FluxService>())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes an issue, add '<AB#XXX>' somewhere in the PR summary. As a minimum, please *always* link to the relevant work items e.g. AB#XXX (work item number in Azure DevOps). Follow the format below carefully, guidance found here: https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops. Note: The Title pattern should be `{work item number}: {title}` -->

# **What this PR does / why we need it**:
This PR contains the changes to add support for flux manifest generation for Helm only service.
[AB#346049](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/346049)

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
*Any relevant testing information and pipeline runs.*

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [x] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)