### PR TITLE
377698: Add support for adopting existing github teams

### DIFF
--- a/.azuredevops/containerApp.yaml
+++ b/.azuredevops/containerApp.yaml
@@ -75,6 +75,10 @@ properties:
             value: "main"
           - name: TeamGitRepo__Organisation
             secretRef: git-repo-org
+          - name: TeamGitRepo__BlacklistedTeams__0
+            value: "ADP-Platform-Admins"
+          - name: TeamGitRepo__AdminLogin
+            value: "adp-platform"
           - name: FluxTemplatesGitRepo__Name
             value: "adp-flux-templates"
           - name: FluxTemplatesGitRepo__Reference

--- a/src/ADP.Portal.Api/ADP.Portal.Api.csproj
+++ b/src/ADP.Portal.Api/ADP.Portal.Api.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>0.1.31</Version>
+    <Version>0.1.32</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <InvariantGlobalization>true</InvariantGlobalization>

--- a/src/ADP.Portal.Api/appsettings.Development.json
+++ b/src/ADP.Portal.Api/appsettings.Development.json
@@ -16,7 +16,11 @@
   "TeamGitRepo": {
     "Name": "adp-teams-config",
     "Reference": "main",
-    "Organisation": "defra-adp-sandpit"
+    "Organisation": "defra-adp-sandpit",
+    "BlacklistedTeams": [
+      "ADP-Platform-Admins"
+    ],
+    "AdminLogin": "adp-platform"
   },
   "FluxTemplatesGitRepo": {
     "Name": "adp-flux-templates",

--- a/src/ADP.Portal.Core/Git/Entities/GitHubOptions.cs
+++ b/src/ADP.Portal.Core/Git/Entities/GitHubOptions.cs
@@ -3,4 +3,6 @@
 public record GitHubOptions
 {
     public required string Organisation { get; set; }
+    public List<string> BlacklistedTeams { get; set; } = [];
+    public required string AdminLogin { get; set; }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes an issue, add '<AB#XXX>' somewhere in the PR summary. As a minimum, please *always* link to the relevant work items e.g. AB#XXX (work item number in Azure DevOps). Follow the format below carefully, guidance found here: https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops. Note: The Title pattern should be `{work item number}: {title}` -->

# **What this PR does / why we need it**:
[AB#377698](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/377698) Add support for adopting a github team if the team is not a blacklisted team (e.g. ADP-Platform-Admins), and it has the admin account as a member (e.g. adp-platform). This is to allow teams to be reused across environments.

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
*Any relevant testing information and pipeline runs.*

# **How does this PR make you feel**:
![gif](https://giphy.com/)