### PR TITLE
338415:Flux manifest patch values

### DIFF
--- a/src/ADP.Portal.Api/ADP.Portal.Api.csproj
+++ b/src/ADP.Portal.Api/ADP.Portal.Api.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>0.1.33</Version>
+    <Version>0.1.34</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <InvariantGlobalization>true</InvariantGlobalization>

--- a/src/ADP.Portal.Api/Controllers/FluxManifestController.cs
+++ b/src/ADP.Portal.Api/Controllers/FluxManifestController.cs
@@ -1,0 +1,37 @@
+﻿using ADP.Portal.Api.Models.Flux;
+using ADP.Portal.Core.Git.Services;
+using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ADP.Portal.Api.Controllers;
+
+[Route("api/[controller]")]
+[ApiVersion("1.0")]
+[ApiController]
+public class FluxManifestController : ControllerBase
+{
+
+    private readonly IFluxManifestService fluxManifestService;
+    private readonly ILogger<FluxManifestController> logger;
+
+    public FluxManifestController(IFluxManifestService fluxManifestService, ILogger<FluxManifestController> logger)
+    {
+
+        this.fluxManifestService = fluxManifestService;
+        this.logger = logger;
+    }
+
+    [HttpGet("templates/service/{templateType}/patch-values")]
+    public async Task<ActionResult> GetFluxServiceTemplateManifest( [FromRoute] string templateType)
+    {
+        if (!Enum.TryParse<ServiceTemplateType>(templateType, true, out var parsedTemplateType))
+        {
+            return BadRequest("Invalid template type. Allowed values are 'Deploy' and 'Infra'.");
+        }
+
+        logger.LogInformation("Getting flux service template patch values for {TemplateType}", templateType);
+        var result = await fluxManifestService.GetFluxServiceTemplatePatchValuesAsync(parsedTemplateType.ToString().ToLower());
+        return Ok(result);
+    }
+}

--- a/src/ADP.Portal.Api/Controllers/FluxManifestController.cs
+++ b/src/ADP.Portal.Api/Controllers/FluxManifestController.cs
@@ -1,7 +1,6 @@
 ﻿using ADP.Portal.Api.Models.Flux;
 using ADP.Portal.Core.Git.Services;
 using Asp.Versioning;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 namespace ADP.Portal.Api.Controllers;
@@ -17,13 +16,17 @@ public class FluxManifestController : ControllerBase
 
     public FluxManifestController(IFluxManifestService fluxManifestService, ILogger<FluxManifestController> logger)
     {
-
         this.fluxManifestService = fluxManifestService;
         this.logger = logger;
     }
 
+    /// <summary>
+    /// Get Patch values for Flux service template.
+    /// </summary>
+    /// <param name="templateType"></param>
+    /// <returns></returns>
     [HttpGet("templates/service/{templateType}/patch-values")]
-    public async Task<ActionResult> GetFluxServiceTemplateManifest( [FromRoute] string templateType)
+    public async Task<ActionResult> GetFluxServiceTemplateManifest([FromRoute] string templateType)
     {
         if (!Enum.TryParse<ServiceTemplateType>(templateType, true, out var parsedTemplateType))
         {

--- a/src/ADP.Portal.Api/Models/Flux/ServiceTemplateType.cs
+++ b/src/ADP.Portal.Api/Models/Flux/ServiceTemplateType.cs
@@ -1,0 +1,8 @@
+﻿namespace ADP.Portal.Api.Models.Flux
+{
+    public enum ServiceTemplateType
+    {
+        Deploy,
+        Infra
+    }
+}

--- a/src/ADP.Portal.Api/Program.cs
+++ b/src/ADP.Portal.Api/Program.cs
@@ -100,7 +100,9 @@ namespace ADP.Portal.Api
             builder.Services.AddScoped<ICacheService, CacheService>();
             builder.Services.AddMemoryCache();
             builder.Services.AddScoped<IGroupsConfigService, GroupsConfigService>();
+            builder.Services.AddScoped<IFluxTemplateService, FluxTemplateService>();
             builder.Services.AddScoped<IFluxTeamConfigService, FluxTeamConfigService>();
+            builder.Services.AddScoped<IFluxManifestService, FluxManifestService>();
             builder.Services.AddSingleton(provider =>
             {
                 return new DeserializerBuilder()

--- a/src/ADP.Portal.Core/Git/Infrastructure/GitHubRepository.cs
+++ b/src/ADP.Portal.Core/Git/Infrastructure/GitHubRepository.cs
@@ -67,7 +67,6 @@ namespace ADP.Portal.Core.Git.Infrastructure
 
             var pullRequest = new NewPullRequest(message, branchName, gitRepo.Reference);
             var createdPullRequest = await gitHubClient.PullRequest.Create(repository.Owner.Login, repository.Name, pullRequest);
-            
             return createdPullRequest != null;
         }
 

--- a/src/ADP.Portal.Core/Git/Infrastructure/GitHubRepository.cs
+++ b/src/ADP.Portal.Core/Git/Infrastructure/GitHubRepository.cs
@@ -67,7 +67,7 @@ namespace ADP.Portal.Core.Git.Infrastructure
 
             var pullRequest = new NewPullRequest(message, branchName, gitRepo.Reference);
             var createdPullRequest = await gitHubClient.PullRequest.Create(repository.Owner.Login, repository.Name, pullRequest);
-
+            
             return createdPullRequest != null;
         }
 

--- a/src/ADP.Portal.Core/Git/Services/CacheService.cs
+++ b/src/ADP.Portal.Core/Git/Services/CacheService.cs
@@ -1,33 +1,31 @@
 ﻿using Microsoft.Extensions.Caching.Memory;
 
-namespace ADP.Portal.Core.Git.Services
+namespace ADP.Portal.Core.Git.Services;
+public class CacheService : ICacheService
 {
-    public class CacheService : ICacheService
+    private readonly IMemoryCache cache;
+    private readonly TimeSpan defaultExpiration;
+
+    public CacheService(IMemoryCache cache)
     {
-        private readonly IMemoryCache cache;
-        private readonly TimeSpan defaultExpiration;
+        this.cache = cache;
+        this.defaultExpiration = CalculateExpiration();
+    }
 
-        public CacheService(IMemoryCache cache)
-        {
-            this.cache = cache;
-            this.defaultExpiration = CalculateExpiration();
-        }
+    public T? Get<T>(string key)
+    {
+        return cache.Get<T>(key) ?? default;
+    }
 
-        public T? Get<T>(string key)
-        {
-            return cache.Get<T>(key) ?? default;
-        }
+    public void Set<T>(string key, T value)
+    {
+        cache.Set(key, value, new MemoryCacheEntryOptions().SetAbsoluteExpiration(defaultExpiration));
+    }
 
-        public void Set<T>(string key, T value)
-        {
-            cache.Set(key, value, new MemoryCacheEntryOptions().SetAbsoluteExpiration(defaultExpiration));
-        }
-
-        private static TimeSpan CalculateExpiration()
-        {
-            DateTime now = DateTime.Now;
-            DateTime nextMidnight = now.Date.AddDays(1);
-            return nextMidnight - now;
-        }
+    private static TimeSpan CalculateExpiration()
+    {
+        DateTime now = DateTime.Now;
+        DateTime nextMidnight = now.Date.AddDays(1);
+        return nextMidnight - now;
     }
 }

--- a/src/ADP.Portal.Core/Git/Services/FluxManifestService.cs
+++ b/src/ADP.Portal.Core/Git/Services/FluxManifestService.cs
@@ -1,0 +1,32 @@
+﻿using ADP.Portal.Core.Git.Entities;
+using ADP.Portal.Core.Helpers;
+using Microsoft.Extensions.Logging;
+
+namespace ADP.Portal.Core.Git.Services;
+public class FluxManifestService : IFluxManifestService
+{
+    private readonly IFluxTemplateService fluxTemplateService;
+    private readonly ILogger<FluxManifestService> logger;
+
+    public FluxManifestService(IFluxTemplateService fluxTemplateService, ILogger<FluxManifestService> logger)
+    {
+        this.fluxTemplateService = fluxTemplateService;
+        this.logger = logger;
+    }
+
+    public async Task<Dictionary<object, object>?> GetFluxServiceTemplatePatchValuesAsync(string templateType)
+    {
+        var path = $"{Constants.Flux.Templates.SERVICE_FOLDER}/{templateType}/environment/patch.yaml";
+        logger.LogDebug("Getting flux service template patch values from {Path}", path);
+
+        var template = await fluxTemplateService.GetFluxTemplateAsync(path);
+        if (template != null)
+        {
+            var values = new YamlQuery(template.Content).On(Constants.Flux.Templates.SPEC_KEY).Get(Constants.Flux.Templates.VALUES_KEY).ToList<Dictionary<object, object>>();
+            if (values?.Count > 0)
+                return values[0];
+        }
+        logger.LogDebug("Flux service template patch values not found for {TemplateType}", templateType);
+        return default;
+    }
+}

--- a/src/ADP.Portal.Core/Git/Services/FluxTeamConfigService.cs
+++ b/src/ADP.Portal.Core/Git/Services/FluxTeamConfigService.cs
@@ -110,7 +110,7 @@ namespace ADP.Portal.Core.Git.Services
                     await MergeEnvTeamsManifestsAsync(teamConfig.ProgrammeName, teamConfig.TeamName, services, generatedFiles);
 
                     logger.LogDebug("Pushing manifests to the repository:{FluxServiceRepo} for the team:'{TeamName}', service:'{ServiceName}' and environment:'{Environment}'.", fluxServiceRepo.Name, teamName, serviceName, environment);
-                    await PushFilesToFluxRepository(fluxServiceRepo, teamName, serviceName, generatedFiles);
+                    await PushFilesToFluxRepository(fluxServiceRepo, teamName, serviceName, environment, generatedFiles);
                 }
             }
 
@@ -472,15 +472,20 @@ namespace ADP.Portal.Core.Git.Services
             }
         }
 
-        private async Task PushFilesToFluxRepository(GitRepo gitRepoFluxServices, string teamName, string? serviceName, Dictionary<string, FluxTemplateFile> generatedFiles)
+        private async Task PushFilesToFluxRepository(GitRepo gitRepoFluxServices, string teamName, string? serviceName, string? environment, Dictionary<string, FluxTemplateFile> generatedFiles)
         {
-            var branchName = $"refs/heads/features/{teamName}{(string.IsNullOrEmpty(serviceName) ? "" : $"-{serviceName}")}";
+            var branchName = string.Concat("refs/heads/features/", teamName,
+                                    string.IsNullOrEmpty(serviceName) ? "" : $"-{serviceName}",
+                                    string.IsNullOrEmpty(environment) ? "" : $"-{environment}");
+
             var branchRef = await gitHubRepository.GetBranchAsync(gitRepoFluxServices, branchName);
 
             string message;
             if (branchRef == null)
             {
-                message = string.IsNullOrEmpty(serviceName) ? $"{teamName.ToUpper()} Manifest" : $"{serviceName.ToUpper()} Manifest";
+                message = string.Concat(string.IsNullOrEmpty(serviceName) ? $"{teamName.ToUpper()}" : $"{serviceName.ToUpper()}",
+                    string.IsNullOrEmpty(environment) ? "" : $" {environment.ToUpper()}",
+                    " Manifest");
             }
             else
             {

--- a/src/ADP.Portal.Core/Git/Services/FluxTemplateService.cs
+++ b/src/ADP.Portal.Core/Git/Services/FluxTemplateService.cs
@@ -1,5 +1,4 @@
 ﻿using ADP.Portal.Core.Git.Entities;
-using ADP.Portal.Core.Git.Extensions;
 using ADP.Portal.Core.Git.Infrastructure;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -18,7 +17,7 @@ public class FluxTemplateService : IFluxTemplateService
         this.logger = logger;
         this.fluxTemplatesRepo = gitRepoOptions.Get(Constants.GitRepo.TEAM_FLUX_TEMPLATES_CONFIG);
     }
- 
+
     public async Task<IEnumerable<KeyValuePair<string, FluxTemplateFile>>> GetFluxTemplatesAsync()
     {
         var cacheKey = $"flux-templates-{fluxTemplatesRepo.Reference}";

--- a/src/ADP.Portal.Core/Git/Services/FluxTemplateService.cs
+++ b/src/ADP.Portal.Core/Git/Services/FluxTemplateService.cs
@@ -1,0 +1,45 @@
+﻿using ADP.Portal.Core.Git.Entities;
+using ADP.Portal.Core.Git.Extensions;
+using ADP.Portal.Core.Git.Infrastructure;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace ADP.Portal.Core.Git.Services;
+public class FluxTemplateService : IFluxTemplateService
+{
+    private readonly IGitHubRepository gitHubRepository;
+    private readonly ICacheService cacheService;
+    private readonly ILogger<FluxTemplateService> logger;
+    private readonly GitRepo fluxTemplatesRepo;
+    public FluxTemplateService(IGitHubRepository gitHubRepository, IOptionsSnapshot<GitRepo> gitRepoOptions, ICacheService cacheService, ILogger<FluxTemplateService> logger)
+    {
+        this.gitHubRepository = gitHubRepository;
+        this.cacheService = cacheService;
+        this.logger = logger;
+        this.fluxTemplatesRepo = gitRepoOptions.Get(Constants.GitRepo.TEAM_FLUX_TEMPLATES_CONFIG);
+    }
+ 
+    public async Task<IEnumerable<KeyValuePair<string, FluxTemplateFile>>> GetFluxTemplatesAsync()
+    {
+        var cacheKey = $"flux-templates-{fluxTemplatesRepo.Reference}";
+
+        logger.LogDebug("Getting flux templates from cache");
+        var templates = cacheService.Get<IEnumerable<KeyValuePair<string, FluxTemplateFile>>>(cacheKey);
+        if (templates == null)
+        {
+            logger.LogDebug("Getting flux templates from GitHub");
+            templates = await gitHubRepository.GetAllFilesAsync(fluxTemplatesRepo, Constants.Flux.Templates.GIT_REPO_TEMPLATE_PATH);
+
+            logger.LogDebug("Caching flux templates");
+            cacheService.Set(cacheKey, templates);
+        }
+
+        return templates;
+    }
+
+    public async Task<FluxTemplateFile?> GetFluxTemplateAsync(string path)
+    {
+        var templates = await GetFluxTemplatesAsync();
+        return templates.FirstOrDefault(t => t.Key == path).Value;
+    }
+}

--- a/src/ADP.Portal.Core/Git/Services/ICacheService.cs
+++ b/src/ADP.Portal.Core/Git/Services/ICacheService.cs
@@ -1,8 +1,6 @@
-﻿namespace ADP.Portal.Core.Git.Services
+﻿namespace ADP.Portal.Core.Git.Services;
+public interface ICacheService
 {
-    public interface ICacheService
-    {
-        T? Get<T>(string key);
-        void Set<T>(string key, T value);
-    }
+    T? Get<T>(string key);
+    void Set<T>(string key, T value);
 }

--- a/src/ADP.Portal.Core/Git/Services/IFluxManifestService.cs
+++ b/src/ADP.Portal.Core/Git/Services/IFluxManifestService.cs
@@ -1,0 +1,8 @@
+﻿using ADP.Portal.Core.Git.Entities;
+
+namespace ADP.Portal.Core.Git.Services;
+
+public interface IFluxManifestService
+{
+    public Task<Dictionary<object,object>?> GetFluxServiceTemplatePatchValuesAsync(string templateType);
+}

--- a/src/ADP.Portal.Core/Git/Services/IFluxTemplateService.cs
+++ b/src/ADP.Portal.Core/Git/Services/IFluxTemplateService.cs
@@ -1,0 +1,9 @@
+﻿using ADP.Portal.Core.Git.Entities;
+
+namespace ADP.Portal.Core.Git.Services;
+
+public interface IFluxTemplateService
+{
+    Task<IEnumerable<KeyValuePair<string, FluxTemplateFile>>> GetFluxTemplatesAsync();
+    Task<FluxTemplateFile?> GetFluxTemplateAsync(string path);
+}

--- a/test/ADP.Portal.Api.Tests/Controllers/FluxManifestControllerTests.cs
+++ b/test/ADP.Portal.Api.Tests/Controllers/FluxManifestControllerTests.cs
@@ -1,0 +1,62 @@
+﻿using ADP.Portal.Api.Controllers;
+using ADP.Portal.Core.Git.Services;
+using AutoFixture;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ADP.Portal.Api.Tests.Controllers;
+
+[TestFixture]
+public class FluxManifestControllerTests
+{
+    private Fixture fixture = null!;
+    private IFluxManifestService fluxManifestService = null!;
+    private ILogger<FluxManifestController> logger = null!;
+    private FluxManifestController fluxManifestController = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        fixture = new Fixture();
+        fluxManifestService = Substitute.For<IFluxManifestService>();
+        logger = Substitute.For<ILogger<FluxManifestController>>();
+        fluxManifestController = new FluxManifestController(fluxManifestService, logger);
+    }
+
+    [Test]
+    public async Task GetFluxServiceTemplateManifest_ReturnsBadRequest_WhenTemplateTypeIsInvalid()
+    {
+        // Arrange
+        var templateType = fixture.Create<string>();
+
+        // Act
+        var result = await fluxManifestController.GetFluxServiceTemplateManifest(templateType);
+
+        // Assert
+        Assert.That(result, Is.InstanceOf<BadRequestObjectResult>());
+    }
+
+    [Test]
+    public async Task GetFluxServiceTemplateManifest_ReturnsOk_WhenTemplateTypeIsValid()
+    {
+        // Arrange
+        var templateType = "Deploy";
+        var patchValues = fixture.Create<Dictionary<object, object>?>();
+        fluxManifestService.GetFluxServiceTemplatePatchValuesAsync(templateType.ToLower()).Returns(patchValues);
+
+        // Act
+        var result = await fluxManifestController.GetFluxServiceTemplateManifest(templateType);
+
+        // Assert
+        Assert.That(result,Is.InstanceOf<OkObjectResult>());
+        var okResult = result as OkObjectResult;
+        Assert.That(okResult?.Value, Is.EqualTo(patchValues));
+    }
+}

--- a/test/ADP.Portal.Core.Tests/Git/Services/FluxManifestServiceTests.cs
+++ b/test/ADP.Portal.Core.Tests/Git/Services/FluxManifestServiceTests.cs
@@ -1,0 +1,72 @@
+﻿using ADP.Portal.Core.Git.Entities;
+using ADP.Portal.Core.Git.Services;
+using AutoFixture;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace ADP.Portal.Core.Tests.Git.Services;
+
+[TestFixture]
+public class FluxManifestServiceTests
+{
+    private Fixture fixture = null!;
+    private IFluxTemplateService fluxTemplateService = null!;
+    private ILogger<FluxManifestService> logger = null!;
+    private FluxManifestService fluxManifestService = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        fixture = new Fixture();
+        fluxTemplateService = Substitute.For<IFluxTemplateService>();
+        logger = Substitute.For<ILogger<FluxManifestService>>();
+        fluxManifestService = new FluxManifestService(fluxTemplateService, logger);
+    }
+
+    [Test]
+    public async Task GetFluxServiceTemplatePatchValuesAsync_ReturnsValues_WhenTemplateExists()
+    {
+        // Arrange
+        var templateType = fixture.Create<string>();
+        var path = $"{Constants.Flux.Templates.SERVICE_FOLDER}/{templateType}/environment/patch.yaml";
+        var file = new Dictionary<object, object>
+            {
+                {
+                    Constants.Flux.Templates.SPEC_KEY, new Dictionary<object, object>
+                    {
+                        {
+                            Constants.Flux.Templates.VALUES_KEY, new Dictionary<object, object>
+                            {
+                                { Constants.Flux.Templates.POSTGRESRESOURCEGROUPNAME_KEY, "group" },
+                                { Constants.Flux.Templates.POSTGRESSERVERNAME_KEY, "server" }
+                            }
+                        }
+                    }
+                }
+            };
+        fluxTemplateService.GetFluxTemplateAsync(path).Returns(new FluxTemplateFile(file));
+
+        // Act
+        var result = await fluxManifestService.GetFluxServiceTemplatePatchValuesAsync(templateType);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+    }
+
+    [Test]
+    public async Task GetFluxServiceTemplatePatchValuesAsync_ReturnsNull_WhenTemplateDoesNotExist()
+    {
+        // Arrange
+        var templateType = fixture.Create<string>();
+        var path = $"{Constants.Flux.Templates.SERVICE_FOLDER}/{templateType}/environment/patch.yaml";
+        fluxTemplateService.GetFluxTemplateAsync(path).Returns((FluxTemplateFile?)null);
+
+        // Act
+        var result = await fluxManifestService.GetFluxServiceTemplatePatchValuesAsync(templateType);
+
+        // Assert
+        Assert.That(result, Is.Null);
+    }
+
+}

--- a/test/ADP.Portal.Core.Tests/Git/Services/FluxTemplateServiceTests.cs
+++ b/test/ADP.Portal.Core.Tests/Git/Services/FluxTemplateServiceTests.cs
@@ -1,0 +1,96 @@
+﻿using ADP.Portal.Core.Git.Entities;
+using ADP.Portal.Core.Git.Infrastructure;
+using ADP.Portal.Core.Git.Services;
+using AutoFixture;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace ADP.Portal.Core.Tests.Git.Services;
+
+[TestFixture]
+public class FluxTemplateServiceTests
+{
+    private ICacheService cacheService = null!;
+    private IGitHubRepository gitHubRepository = null!;
+    private FluxTemplateService fluxTemplateService = null!;
+    private ILogger<FluxTemplateService> logger = null!;
+    private readonly IOptionsSnapshot<GitRepo> gitRepoOptions = Substitute.For<IOptionsSnapshot<GitRepo>>();
+    private GitRepo fluxTemplateRepo = null!;
+    private IFixture fixture = null!;
+    [SetUp]
+    public void SetUp()
+    {
+        fixture = new Fixture();
+        cacheService = Substitute.For<ICacheService>();
+        gitHubRepository = Substitute.For<IGitHubRepository>();
+        logger = Substitute.For<ILogger<FluxTemplateService>>();
+        fluxTemplateRepo = fixture.Build<GitRepo>().Create();
+        gitRepoOptions.Get(Constants.GitRepo.TEAM_FLUX_TEMPLATES_CONFIG).Returns(fluxTemplateRepo);
+        fluxTemplateService = new FluxTemplateService(gitHubRepository, gitRepoOptions, cacheService, logger);
+    }
+
+    [Test]
+    public async Task GetFluxTemplatesAsync_ReturnsTemplatesFromCache_WhenTemplatesAreCached()
+    {
+        // Arrange
+        var cachedTemplates = fixture.CreateMany<KeyValuePair<string, FluxTemplateFile>>(5).ToList();
+        cacheService.Get<IEnumerable<KeyValuePair<string, FluxTemplateFile>>>(Arg.Any<string>()).Returns(cachedTemplates);
+
+        // Act
+        var result = await fluxTemplateService.GetFluxTemplatesAsync();
+
+        // Assert
+        Assert.That(result, Is.EqualTo(cachedTemplates));
+        await gitHubRepository.DidNotReceive().GetAllFilesAsync(Arg.Any<GitRepo>(), Arg.Any<string>());
+    }
+
+    [Test]
+    public async Task GetFluxTemplatesAsync_ReturnsTemplatesFromGitHub_WhenTemplatesAreNotCached()
+    {
+        // Arrange
+        var templates = fixture.CreateMany<KeyValuePair<string, FluxTemplateFile>>(5).ToList();
+        cacheService.Get<IEnumerable<KeyValuePair<string, FluxTemplateFile>>>(Arg.Any<string>()).Returns((List<KeyValuePair<string, FluxTemplateFile>>?)null);
+        gitHubRepository.GetAllFilesAsync(Arg.Any<GitRepo>(), Arg.Any<string>()).Returns(templates);
+
+        // Act
+        var result = await fluxTemplateService.GetFluxTemplatesAsync();
+
+        // Assert
+        Assert.That(result, Is.EqualTo(templates));
+        cacheService.Received().Set(Arg.Any<string>(), templates);
+    }
+
+    [Test]
+    public async Task GetFluxTemplateAsync_ReturnsTemplate_WhenTemplateExists()
+    {
+        // Arrange
+        var path = fixture.Create<string>();
+        var templates = fixture.CreateMany<KeyValuePair<string, FluxTemplateFile>>(5).ToList();
+        templates.Add(new KeyValuePair<string, FluxTemplateFile>(path, fixture.Create<FluxTemplateFile>()));
+        cacheService.Get<IEnumerable<KeyValuePair<string, FluxTemplateFile>>>(Arg.Any<string>()).Returns(templates);
+
+        // Act
+        var result = await fluxTemplateService.GetFluxTemplateAsync(path);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result, Is.EqualTo(templates.First(t => t.Key == path).Value));
+    }
+
+    [Test]
+    public async Task GetFluxTemplateAsync_ReturnsNull_WhenTemplateDoesNotExist()
+    {
+        // Arrange
+        var path = fixture.Create<string>();
+        var templates = fixture.CreateMany<KeyValuePair<string, FluxTemplateFile>>(5).ToList();
+        cacheService.Get<IEnumerable<KeyValuePair<string, FluxTemplateFile>>>(Arg.Any<string>()).Returns(templates);
+
+        // Act
+        var result = await fluxTemplateService.GetFluxTemplateAsync(path);
+
+        // Assert
+        Assert.That(result, Is.Null);
+    }
+}

--- a/test/ADP.Portal.Core.Tests/Git/Services/FluxTemplateServiceTests.cs
+++ b/test/ADP.Portal.Core.Tests/Git/Services/FluxTemplateServiceTests.cs
@@ -18,7 +18,7 @@ public class FluxTemplateServiceTests
     private ILogger<FluxTemplateService> logger = null!;
     private readonly IOptionsSnapshot<GitRepo> gitRepoOptions = Substitute.For<IOptionsSnapshot<GitRepo>>();
     private GitRepo fluxTemplateRepo = null!;
-    private IFixture fixture = null!;
+    private Fixture fixture = null!;
     [SetUp]
     public void SetUp()
     {


### PR DESCRIPTION
# **What this PR does / why we need it**:
Added a new endpoint to retrive flux service template patch values.
[AB#338415](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/338415)

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
*Any relevant testing information and pipeline runs.*

# Checklist (please delete before completing or setting auto-complete)
- [ ] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [ ] Title pattern should be `{work item number}: {title}`
- [ ] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)